### PR TITLE
Fix nuke.js for ESM

### DIFF
--- a/nuke.js
+++ b/nuke.js
@@ -1,6 +1,5 @@
-const fs = require('fs');
-const path = require('path');
-const rimraf = require('rimraf');
+import path from 'path';
+import rimraf from 'rimraf';
 
 const args = process.argv.slice(2);
 


### PR DESCRIPTION
## Summary
- convert cleanup script to use ESM imports

## Testing
- `npm run build` *(fails: run-s not found)*

------
https://chatgpt.com/codex/tasks/task_e_684140a26fb083218e7f0ec2eb858f39