### PR TITLE
Add lazy loading on images

### DIFF
--- a/config/markdown.js
+++ b/config/markdown.js
@@ -1,0 +1,15 @@
+import markdownIt from 'markdown-it';
+
+export default function(eleventyConfig) {
+    const markdownLib = markdownIt({ html: true }).use(function(md) {
+        const defaultImageRule = md.renderer.rules.image || function(tokens, idx, options, env, self) {
+            return self.renderToken(tokens, idx, options);
+        };
+        md.renderer.rules.image = function (tokens, idx, options, env, self) {
+            tokens[idx].attrSet('loading', 'lazy');
+            return defaultImageRule(tokens, idx, options, env, self);
+        };
+    });
+
+    eleventyConfig.setLibrary('md', markdownLib);
+};

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -3,6 +3,7 @@ import pluginRss from "@11ty/eleventy-plugin-rss";
 import filters from './config/filters.js';
 import nunjucksShortcodes from './config/nunjucks.js';
 import imagesPlugin from './config/images.js';
+import markdownPlugin from './config/markdown.js';
 
 export default function (eleventyConfig) {
 
@@ -31,6 +32,8 @@ export default function (eleventyConfig) {
 
     // Filters
     eleventyConfig.addPlugin(filters);
+    // Markdown
+    eleventyConfig.addPlugin(markdownPlugin);
 
     // Collections
     eleventyConfig.addCollection("allcontent", function (collectionApi) {

--- a/src/_includes/layouts/recipe.njk
+++ b/src/_includes/layouts/recipe.njk
@@ -19,7 +19,7 @@
                     {% endif %}
                 </p>
                 {% if image %}
-                    <p><img src="{{ image }}" alt="{{ imageAlt }}"/></p>
+                    <p><img src="{{ image }}" alt="{{ imageAlt }}" loading="lazy"/></p>
                 {% endif %}
                 {{ content | safe }}
             </article>

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -29,7 +29,7 @@ pagination:
                     <a href="https://reinierladan.nl">Reinier Ladan</a>
                 </p>
                 {% if post.data.image %}
-                    <p><img src="{{ post.data.image }}" alt="{{ post.data.imageAlt }}"/></p>
+                    <p><img src="{{ post.data.image }}" alt="{{ post.data.imageAlt }}" loading="lazy"/></p>
                 {% endif %}
                 <div class="post-content">{{ post.templateContent | safe }}</div>
             </article>

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -23,7 +23,7 @@ permalink: /onderwerp/{{ tag }}/
     
     {% for post in taglist | reverse %}
         <li class="recept-cta">
-            <a href="{{ post.url }}"><img src="{{ post.data.image | getthumb }}" />{{ post.data.title }}</a>
+            <a href="{{ post.url }}"><img src="{{ post.data.image | getthumb }}" loading="lazy" />{{ post.data.title }}</a>
         </li>
     {% endfor %}
 </ol>


### PR DESCRIPTION
## Summary
- add markdown-it plugin that adds `loading="lazy"` on images
- update recipe, tag, and blog templates to include lazy loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841722e0c7c8321aaa7fbe7fa4d683d