### PR TITLE
Use eleventy-img metadata for responsive images

### DIFF
--- a/config/images.js
+++ b/config/images.js
@@ -17,9 +17,15 @@ async function generateImages() {
     for (const f of files) {
         const subDir = path.dirname(f).replace(/^\.\/src\/images/, "");
 
+        let ext = path.extname(f).toLowerCase();
+        let formats = ['webp', 'jpeg'];
+        if (ext === '.png') {
+            formats = ['webp', 'png'];
+        }
+
         let metadata = await Image(f, {
             widths: [THUMB, FULL],
-            formats: ['webp', 'jpeg'],
+            formats,
             urlPath: "/images/" + subDir,
             outputDir: "./_site/images/" + subDir,
             sharpJpegOptions: {
@@ -106,9 +112,15 @@ export default function (eleventyConfig) {
         if (!metadataStore[src]) {
             const file = './src' + src;
             const subDir = path.dirname(file).replace(/^\.\/src\/images/, "");
+            let ext = path.extname(file).toLowerCase();
+            let formats = ['webp', 'jpeg'];
+            if (ext === '.png') {
+                formats = ['webp', 'png'];
+            }
+
             metadataStore[src] = await Image(file, {
                 widths: [THUMB, FULL],
-                formats: ['webp', 'jpeg'],
+                formats,
                 urlPath: '/images/' + subDir,
                 outputDir: './_site/images/' + subDir,
                 sharpJpegOptions: {

--- a/src/_includes/head-components/social-image.njk
+++ b/src/_includes/head-components/social-image.njk
@@ -7,7 +7,13 @@
 {% elseif image %}
     {% if imageMeta and imageMeta[image] %}
         {% set meta = imageMeta[image] %}
-        <meta property="og:image" content="{{ meta.jpeg[meta.jpeg.length - 1].url }}"/>
+        {% if meta.jpeg %}
+            <meta property="og:image" content="{{ meta.jpeg[meta.jpeg.length - 1].url }}"/>
+        {% elseif meta.png %}
+            <meta property="og:image" content="{{ meta.png[meta.png.length - 1].url }}"/>
+        {% else %}
+            <meta property="og:image" content="{{ image }}"/>
+        {% endif %}
     {% else %}
         <meta property="og:image" content="{{ image }}"/>
     {% endif %}

--- a/src/_includes/head-components/social-image.njk
+++ b/src/_includes/head-components/social-image.njk
@@ -5,7 +5,12 @@
 {% elseif socialPreview %}
     <meta property="og:image" content="/images/social-preview-images/{{ page.date | postDate }}-{{ title | slugify }}-preview.jpeg"/>
 {% elseif image %}
-    <meta property="og:image" content="{{ image }}"/>
+    {% if imageMeta and imageMeta[image] %}
+        {% set meta = imageMeta[image] %}
+        <meta property="og:image" content="{{ meta.jpeg[meta.jpeg.length - 1].url }}"/>
+    {% else %}
+        <meta property="og:image" content="{{ image }}"/>
+    {% endif %}
 {% else %}
     <meta property="og:image" content="/images/fyi-social.jpg"/>
 {% endif %}

--- a/src/_includes/layouts/recipe.njk
+++ b/src/_includes/layouts/recipe.njk
@@ -19,7 +19,7 @@
                     {% endif %}
                 </p>
                 {% if image %}
-                    <p><img src="{{ image }}" alt="{{ imageAlt }}" loading="lazy"/></p>
+                    <p>{% picture image, imageAlt %}</p>
                 {% endif %}
                 {{ content | safe }}
             </article>

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -29,7 +29,7 @@ pagination:
                     <a href="https://reinierladan.nl">Reinier Ladan</a>
                 </p>
                 {% if post.data.image %}
-                    <p><img src="{{ post.data.image }}" alt="{{ post.data.imageAlt }}" loading="lazy"/></p>
+                    <p>{% picture post.data.image, post.data.imageAlt %}</p>
                 {% endif %}
                 <div class="post-content">{{ post.templateContent | safe }}</div>
             </article>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -29,7 +29,7 @@
         font-kerning: normal;
         overflow-x: hidden;
         width: 100%;
-        background-image: url("/images/fyi-header-repeat.png");
+        background-image: url("/images/fyi-header-repeat.jpg");
         background-position-y: -20px;
         background-repeat:repeat-x;
     }
@@ -152,7 +152,7 @@
     
     header {
         @apply font-fyi-alt font-bold;
-        background-image: url("/images/reinier-fyi-header.png");
+        background-image: url("/images/reinier-fyi-header.jpg");
         background-position-y: -20px;
         background-repeat:no-repeat;
         height: 180px;

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -29,7 +29,7 @@
         font-kerning: normal;
         overflow-x: hidden;
         width: 100%;
-        background-image: url("/images/fyi-header-repeat.jpg");
+        background-image: url("/images/fyi-header-repeat.png");
         background-position-y: -20px;
         background-repeat:repeat-x;
     }
@@ -152,7 +152,7 @@
     
     header {
         @apply font-fyi-alt font-bold;
-        background-image: url("/images/reinier-fyi-header.jpg");
+        background-image: url("/images/reinier-fyi-header.png");
         background-position-y: -20px;
         background-repeat:no-repeat;
         height: 180px;

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -23,7 +23,7 @@ permalink: /onderwerp/{{ tag }}/
     
     {% for post in taglist | reverse %}
         <li class="recept-cta">
-            <a href="{{ post.url }}"><img src="{{ post.data.image | getthumb }}" loading="lazy" />{{ post.data.title }}</a>
+            <a href="{{ post.url }}">{% picture post.data.image, post.data.imageAlt %}{{ post.data.title }}</a>
         </li>
     {% endfor %}
 </ol>


### PR DESCRIPTION
## Summary
- generate WebP and JPEG versions with eleventy-img
- expose image metadata globally and provide `picture` shortcode
- use the `picture` shortcode in post templates
- use processed image in social preview metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841845dadc0832190d05dc8e083c902