### PR TITLE
Move stats include to footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -8,3 +8,4 @@
         <a href="https://github.com/reinier/fyi/blob/main/{{ page.inputPath }}">Bewerk deze pagina op GitHub</a>, dit is ook de beste plek voor het geven van een suggestie of het oplossen van een bug.
     </p>
 </footer>
+{% include './stats.njk' %}

--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -28,5 +28,4 @@
         </script>
     {% endif %}
     <!-- End structured data -->
-    {% include './stats.njk' %}
 </head>


### PR DESCRIPTION
## Summary
- relocate `stats.njk` include from `<head>` to the footer so the analytics script loads after the page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68418466f19c8321bc2f8a8b08387a0a